### PR TITLE
remove split card definition from script start

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ presets = {
     "includeMasterpieces": True, # if the set has masterpieces, let's get those too
     "oldRSS": False, # maybe MTGS hasn't updated their spoiler.rss but new cards have leaked
     "split_cards": {
-        "Grind": "Dust"
     },
     "siteorder": ['scryfall','mtgs','mythicspoiler'], # if we want to use one site before another for card data TODO
     "imageorder": ['wotc','scryfall','mtgs','mythicspoiler'], # prioritize images from certain sources


### PR DESCRIPTION
Can all 
```
     "split_cards": {
     },
```
be removed?

You said something that it's not needed there any longer?