### PR TITLE
enable pip caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,15 @@ sudo: false
 
 language: python
 
-#cache: pip
-
-addons:
-  apt:
-    packages:
-      - python-lxml # apt > pip
+cache: pip # enable cache for "$HOME/.pip-cache" directory
 
 before_install:
   - pip install commentjson
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:
-#  - export CFLAGS=-O0 # considerably speed-up build time for lxml
-  - pip install -r requirements.txt #--cache-dir $HOME/.pip-cache
+  - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
+  - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
 
 script: bash ./deploy.sh
 


### PR DESCRIPTION
Just caches the downloading, still needs to build packages.
https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone

Difficult to cache the binaries as well (and just install).
More Information and links: https://github.com/Cockatrice/Magic-Spoiler/issues/50#issuecomment-312547230

Will still save about ~2min of ci time!

Will do more testing on the other branch with the other options like apt addons and maybe docker.
<br>

---

on_success: always
on_failure: always
on_start: always 

I also think we should lower the amount of notifications!
`options: [always|never|change] default: always`
Maybe go with **change, change, never**? (as I've no idea what change on `on_start` would do...)