### PR TITLE
enable pip cache for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ language: python
 cache: pip # enable cache for "$HOME/.pip-cache" directory
 
 before_install:
-  - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
-  - pip install commentjson --cache-dir $HOME/.pip-cache
+  - pip install commentjson
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: false # force container-based builds (no start-up time!)
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ language: python
 cache: pip # enable cache for "$HOME/.pip-cache" directory
 
 before_install:
+  - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
   - pip install commentjson
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:
-  - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
   - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
 
 script: bash ./deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ deploy:
 env:
   global:
   - ENCRYPTION_LABEL: ec68c19ba263
-- COMMIT_AUTHOR_EMAIL: you@example.com
+  - COMMIT_AUTHOR_EMAIL: you@example.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
+sudo: false
+
 language: python
+
+cache: pip # enable cache for "$HOME/.pip-cache" directory
+
 before_install:
   - pip install commentjson
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
+
 install:
-  - pip install -r requirements.txt
+  - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
+  - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
+
 script: bash ./deploy.sh
-after_script:   
+
+after_script:
   - sleep 10 # helps travis finish logging
+
 notifications:
   email: false
   webhooks:
@@ -14,7 +24,8 @@ notifications:
       - https://webhooks.gitter.im/e/691b9acffe1def5f9d6b
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
-    on_start: always     # options: [always|never|change] default: always
+    on_start: always    # options: [always|never|change] default: always
+
 deploy:
   provider: releases
   api_key:
@@ -26,7 +37,8 @@ deploy:
   on:
     tags: true
     branch: master
+
 env:
   global:
   - ENCRYPTION_LABEL: ec68c19ba263
-  - COMMIT_AUTHOR_EMAIL: you@example.com
+- COMMIT_AUTHOR_EMAIL: you@example.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ cache: pip # enable cache for "$HOME/.pip-cache" directory
 
 before_install:
   - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
-  - pip install commentjson
+  - pip install commentjson --cache-dir $HOME/.pip-cache
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:
+  - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
   - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
 
 script: bash ./deploy.sh


### PR DESCRIPTION
Just caches the downloading, packages still need to be build.
https://blog.travis-ci.com/2016-05-03-caches-are-coming-to-everyone

Difficult to cache the binaries as well (and just install from the cached builds): https://github.com/Cockatrice/Magic-Spoiler/issues/50#issuecomment-312547230

Will still save about ~3min of CI time! (>60% faster)
--> ~5min down to ~1min 50s! 👍 

I do more testing on the other branch with different options like apt addons and maybe docker.


<br>

Imporant note to keep in mind in case there is a problem with the cache and we have to delete/renew it:
>**Cache fallback**
Please keep in mind: If you delete the cache for a branch other than master, the next build on that branch will fall back to the master cache instead of using an empty cache. This is important if the master branch cache is causing issues, too.
>
>(source: https://blog.travis-ci.com/2014-08-14-new-cache-ui/)