### PR TITLE
prevent log file ending up in cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,19 @@ sudo: false # force container-based builds (no start-up time!)
 
 language: python
 
-cache: pip # enable cache for "$HOME/.cache/pip" directory
-
+cache:
+  pip: true # enable cache for "$HOME/.cache/pip" directory
+  directories:
+    - $HOME/.pip-cache/ # custom pip cache directory
+    - /home/travis/virtualenv/python2.7/lib/python2.7/site-packages
+    
 before_install:
   - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
   - pip install commentjson
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:
-  - pip install -r requirements.txt --cache-dir $HOME/.cache/pip
+  - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
 
 script: bash ./deploy.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: python
 
 cache: pip # enable cache for "$HOME/.pip-cache" directory
 
+before_cache: # before uploading delete log file, not wanted in cache
+  - rm -f $HOME/.cache/pip/log/debug.log
+
 before_install:
   - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
   - pip install commentjson

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: python
 cache:
   pip: true # enable cache for "$HOME/.cache/pip" directory
   directories:
-    - $HOME/.pip-cache/ # custom pip cache directory
     - /home/travis/virtualenv/python2.7/lib/python2.7/site-packages
     
 before_install:
@@ -14,7 +13,7 @@ before_install:
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:
-  - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
+  - pip install -r requirements.txt
 
 script: bash ./deploy.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false # force container-based builds (no start-up time!)
 
 language: python
 
-cache: pip # enable cache for "$HOME/.pip-cache" directory
+cache: pip # enable cache for "$HOME/.cache/pip" directory
 
 before_install:
   - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
@@ -10,12 +10,12 @@ before_install:
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:
-  - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
+  - pip install -r requirements.txt --cache-dir $HOME/.cache/pip
 
 script: bash ./deploy.sh
 
 before_cache: # before uploading delete log file, not wanted in cache
-  - rm -f $TRAVIS_BUILD_DIR/.cache/pip/log/debug.log
+  - rm -f $HOME/.cache/pip/log/debug.log
 
 after_script:
   - sleep 10 # helps travis finish logging

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ language: python
 
 cache: pip # enable cache for "$HOME/.pip-cache" directory
 
-before_cache: # before uploading delete log file, not wanted in cache
-  - rm -f $HOME/.cache/pip/log/debug.log
-
 before_install:
   - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
   - pip install commentjson
@@ -16,6 +13,9 @@ install:
   - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
 
 script: bash ./deploy.sh
+
+before_cache: # before uploading delete log file, not wanted in cache
+  - rm -f $TRAVIS_BUILD_DIR/.cache/pip/log/debug.log
 
 after_script:
   - sleep 10 # helps travis finish logging


### PR DESCRIPTION
idea is to prevent an update of the cache with a created log file on every run
taken from travis docs: https://docs.travis-ci.com/user/caching/#before_cache-phase

not sure if it works as intended regarding the log output... are the directories correctly picked?

<br>

additionally I experimened with caching `site-packages` which results in all requiered packages beeing instant available.
not sure about side effects here.
--> https://stackoverflow.com/questions/19422229/how-to-cache-requirements-for-a-django-project-on-travis-ci (so on requirements updates we need to clear the cache if we cache `site-packages` basically, api or delete cache in travis web interface)

i'm wondering what the benefit of normal cache: pip is!?
the only real impact seemed to be caching of soft-packages, and in the first step the adding of -cO0 flag