### PR TITLE
Travis: run on ubuntu trusty container-based images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false # force container-based builds (no start-up time!)
 
+dist: trusty # force 14.04 trusty build
+
 language: python
 
 cache: pip # enable cache for "$HOME/.pip-cache" directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty # force 14.04 trusty build
 
 language: python
 
-cache: pip # enable cache for "$HOME/.pip-cache" directory
+cache: pip # enable cache for "$HOME/.cache/pip" directory
 
 before_install:
   - export CFLAGS=-O0 # considerably speed-up build time for pip packages (especially lxml), optimizations doesn't matter for ci
@@ -12,7 +12,7 @@ before_install:
   - python verify_files.py # make sure input files are OK before wasting time with prereqs
 
 install:
-  - pip install -r requirements.txt --cache-dir $HOME/.pip-cache
+  - pip install -r requirements.txt
 
 script: bash ./deploy.sh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.13.0
+requests
 feedparser
 lxml
 Pillow


### PR DESCRIPTION
Run on 14.04 Trusty instead of 12.04 Precise
Still beta at the moment, but should change in Q3 2017.

New run time: incredible ~70s 🥇 