### PR TITLE
Fix costs in text

### DIFF
--- a/mtgs_scraper.py
+++ b/mtgs_scraper.py
@@ -214,6 +214,8 @@ def parse_mtgs(mtgs, manual_cards=[], card_corrections=[], delete_cards=[], spli
             cardjson['subtypes'] = subtypes
         cardjson["rarity"] = card['rarity']
         cardjson["text"] = card['rules']
+        if ')' in card['rules']:
+            print card['rules']
         cardjson["type"] = card['type']
 
         workingtypes = card['type']

--- a/mtgs_scraper.py
+++ b/mtgs_scraper.py
@@ -214,8 +214,6 @@ def parse_mtgs(mtgs, manual_cards=[], card_corrections=[], delete_cards=[], spli
             cardjson['subtypes'] = subtypes
         cardjson["rarity"] = card['rarity']
         cardjson["text"] = card['rules']
-        if ')' in card['rules']:
-            print card['rules']
         cardjson["type"] = card['type']
 
         workingtypes = card['type']

--- a/spoilers.py
+++ b/spoilers.py
@@ -93,7 +93,19 @@ def correct_cards(mtgjson, manual_cards=[], card_corrections=[], delete_cards=[]
 
     mtgjson = {"cards": mtgjson2}
 
+    for card in mtgjson['cards']:
+        if '{' in card['text']:
+            card['text'] = re.sub(r'{(.*?)}', replace_costs, card['text'])
     return mtgjson
+
+
+def replace_costs(match):
+    full_cost = match.group(1)
+    individual_costs = []
+    if len(full_cost) > 0:
+        for x in range(0, len(full_cost)):
+            individual_costs.append('{' + str(full_cost[x]).upper() + '}')
+    return ''.join(individual_costs)
 
 
 def error_check(mtgjson, card_corrections={}):


### PR DESCRIPTION
Replaces anything inside `{}` with uppercase, single-character versions with their own `{}`

If mtgs gives us card text of `{3bu}, {t}:` this will translate to `{3}{B}{U}, {T}:`

Partially Fixes #85 
