### PR TITLE
update date/time format in spoiler.xml

### DIFF
--- a/spoilers.py
+++ b/spoilers.py
@@ -495,7 +495,7 @@ def write_combined_xml(mtgjson, setinfos):
     cardsxml.truncate()
     cardsxml.write("<?xml version='1.0' encoding='UTF-8'?>\n"
                    "<cockatrice_carddatabase version='3'>\n")
-    cardsxml.write("<!--\n        created (UTC): " + datetime.datetime.utcnow().strftime("%a %b %d %H:%M:%S %Z %Y")
+    cardsxml.write("<!--\n        created (UTC): " + datetime.datetime.utcnow().strftime("%a, %b %d %Y, %H:%M:%S")
                    + "\n        by: Magic-Spoiler project @ https://github.com/Cockatrice/Magic-Spoiler\n        -->\n")
     cardsxml.write("<sets>\n")
     for setcode in mtgjson:


### PR DESCRIPTION
[`%Z`](http://strftime.org/) not needed (--> [`.utcnow`](https://docs.python.org/2/library/datetime.html) forces UTC)
Would just return empty which resulted in a space
--> see: https://github.com/Cockatrice/Magic-Spoiler/blob/3b7f893261a8f5b4d197a81a05de0a9eaef06c0b/spoiler.xml#L3)

Looks like this now: https://travis-ci.org/Cockatrice/Magic-Spoiler/builds/251982307#L502-L505

<br>

Thinking if I want to bring the most frequent changing value to the front though:
`Mon, Jul 10 2017, 12:38:39` --> `12:38:39, Mon, Jul 10 2017`

The most important value might be date and the least confusing version would be:
`2017-07-10 12:38:39` (also most correct, since 1st,2rd,3th... additions to date are not needed)
or `2017-07-10 (Mon) 12:38:39` with day.

Thougts?

(improvement to #106)