### PR TITLE
New set_info value mythicCode

### DIFF
--- a/cards_corrections.yml
+++ b/cards_corrections.yml
@@ -69,6 +69,6 @@ corrections:                                                            #
 Jace, Cunning Castaway:
   loyalty: 3
 ~Invite the Party:
-  name: Invite the Party
+  name: "Invite the Party"
 ~Belligerent Dinosaur:
-  name: Belligerent Dinosaur
+  name: "Belligerent Dinosaur"

--- a/cards_corrections.yml
+++ b/cards_corrections.yml
@@ -68,3 +68,7 @@ corrections:                                                            #
 
 Jace, Cunning Castaway:
   loyalty: 3
+~Invite the Party:
+  name: Invite the Party
+~Belligerent Dinosaur:
+  name: Belligerent Dinosaur

--- a/main.py
+++ b/main.py
@@ -127,6 +127,8 @@ if __name__ == '__main__':
             manual_cards = []
         mtgs = spoilers.correct_cards(
             mtgs, manual_cards, card_corrections, delete_cards['delete'])  # fix using the fixfiles
+        if not 'mythicCode' in setinfo:
+            setinfo['mythicCode'] = setinfo['code']
         mtgjson = spoilers.get_image_urls(
             mtgs, presets['isfullspoil'], setinfo['code'], setinfo['mythicCode'], setinfo['name'], setinfo['size'], setinfo)  # get images
         if presets['scryfallOnly'] or 'scryfallOnly' in setinfo and setinfo['scryfallOnly']:

--- a/main.py
+++ b/main.py
@@ -128,7 +128,7 @@ if __name__ == '__main__':
         mtgs = spoilers.correct_cards(
             mtgs, manual_cards, card_corrections, delete_cards['delete'])  # fix using the fixfiles
         mtgjson = spoilers.get_image_urls(
-            mtgs, presets['isfullspoil'], setinfo['code'], setinfo['name'], setinfo['size'], setinfo)  # get images
+            mtgs, presets['isfullspoil'], setinfo['code'], setinfo['mythicCode'], setinfo['name'], setinfo['size'], setinfo)  # get images
         if presets['scryfallOnly'] or 'scryfallOnly' in setinfo and setinfo['scryfallOnly']:
             scryfall = scryfall_scraper.get_scryfall(
                 'https://api.scryfall.com/cards/search?q=++e:' + setinfo['code'].lower())

--- a/set_info.yml
+++ b/set_info.yml
@@ -52,6 +52,7 @@ releaseDate: "2017-09-29"
 type: "expansion"
 mtgsurl: "http://www.mtgsalvation.com/spoilers/185-ixalan"
 mtgscardpath: "http://www.mtgsalvation.com/cards/ixalan/"
+mythicCode: "ixa"
 fullSpoil: false
 # masterpieces:
 #   code: "MPS_?"

--- a/spoilers.py
+++ b/spoilers.py
@@ -302,7 +302,7 @@ def remove_corrected_errors(errorlog=[], card_corrections=[], print_fixed=False)
     return errorlog2
 
 
-def get_image_urls(mtgjson, isfullspoil, code, name, size=269, setinfo=False):
+def get_image_urls(mtgjson, isfullspoil, code, mythicCode, name, size=269, setinfo=False):
     IMAGES = 'http://magic.wizards.com/en/content/' + \
         name.lower().replace(' ', '-') + '-cards'
     IMAGES2 = 'http://mythicspoiler.com/newspoilers.html'
@@ -314,7 +314,7 @@ def get_image_urls(mtgjson, isfullspoil, code, name, size=269, setinfo=False):
     text3 = requests.get(IMAGES3).text
     wotcpattern = r'<img alt="{}.*?" src="(?P<img>.*?\.png)"'
     wotcpattern2 = r'<img src="(?P<img>.*?\.png).*?alt="{}.*?"'
-    mythicspoilerpattern = r' src="' + code.lower() + '/cards/{}.*?.jpg">'
+    mythicspoilerpattern = r' src="' + mythicCode.lower() + '/cards/{}.*?.jpg">'
     WOTC = []
     for c in mtgjson['cards']:
         if 'names' in c:


### PR DESCRIPTION
Mythicspoiler is using IXA rather than XLN for some reason. This patch creates a new parameter to account for this. An improvement would be making `mythicCode `default to the usual `code` if it's not provided in `set_info`.