### PR TITLE
Refactor get_image_urls function to use only `setinfo` as input.

### DIFF
--- a/main.py
+++ b/main.py
@@ -127,10 +127,7 @@ if __name__ == '__main__':
             manual_cards = []
         mtgs = spoilers.correct_cards(
             mtgs, manual_cards, card_corrections, delete_cards['delete'])  # fix using the fixfiles
-        if not 'mythicCode' in setinfo:
-            setinfo['mythicCode'] = setinfo['code']
-        mtgjson = spoilers.get_image_urls(
-            mtgs, presets['isfullspoil'], setinfo['code'], setinfo['mythicCode'], setinfo['name'], setinfo['size'], setinfo)  # get images
+        mtgjson = spoilers.get_image_urls(mtgs, presets['isfullspoil'], setinfo)  # get images
         if presets['scryfallOnly'] or 'scryfallOnly' in setinfo and setinfo['scryfallOnly']:
             scryfall = scryfall_scraper.get_scryfall(
                 'https://api.scryfall.com/cards/search?q=++e:' + setinfo['code'].lower())

--- a/spoilers.py
+++ b/spoilers.py
@@ -302,19 +302,21 @@ def remove_corrected_errors(errorlog=[], card_corrections=[], print_fixed=False)
     return errorlog2
 
 
-def get_image_urls(mtgjson, isfullspoil, code, mythicCode, name, size=269, setinfo=False):
+def get_image_urls(mtgjson, isfullspoil, setinfo=False):
+    if not 'mythicCode' in setinfo:
+        setinfo['mythicCode'] = setinfo['code']
     IMAGES = 'http://magic.wizards.com/en/content/' + \
-        name.lower().replace(' ', '-') + '-cards'
+        setinfo['name'].lower().replace(' ', '-') + '-cards'
     IMAGES2 = 'http://mythicspoiler.com/newspoilers.html'
     IMAGES3 = 'http://magic.wizards.com/en/articles/archive/card-image-gallery/' + \
-        name.lower().replace('of', '').replace('  ', ' ').replace(' ', '-')
+        setinfo['name'].lower().replace('of', '').replace('  ', ' ').replace(' ', '-')
 
     text = requests.get(IMAGES).text
     text2 = requests.get(IMAGES2).text
     text3 = requests.get(IMAGES3).text
     wotcpattern = r'<img alt="{}.*?" src="(?P<img>.*?\.png)"'
     wotcpattern2 = r'<img src="(?P<img>.*?\.png).*?alt="{}.*?"'
-    mythicspoilerpattern = r' src="' + mythicCode.lower() + '/cards/{}.*?.jpg">'
+    mythicspoilerpattern = r' src="' + setinfo['mythicCode'].lower() + '/cards/{}.*?.jpg">'
     WOTC = []
     for c in mtgjson['cards']:
         if 'names' in c:


### PR DESCRIPTION
Clean up get image urls function to not require setinfo and individual keys from setinfo redundantly 