### PR TITLE
more future sets info

### DIFF
--- a/mtgs_scraper.py
+++ b/mtgs_scraper.py
@@ -264,7 +264,7 @@ def scrape_mtgs_images(url='http://www.mtgsalvation.com/spoilers/183-hour-of-dev
 
 
 def list_mtgs_gallery(url=''):
-    if url='':
+    if url == '':
         return ''
     page = requests.get(url)
     tree = html.fromstring(page.content)

--- a/mtgs_scraper.py
+++ b/mtgs_scraper.py
@@ -264,6 +264,8 @@ def scrape_mtgs_images(url='http://www.mtgsalvation.com/spoilers/183-hour-of-dev
 
 
 def list_mtgs_gallery(url=''):
+    if url='':
+        return ''
     page = requests.get(url)
     tree = html.fromstring(page.content)
     cards = []

--- a/set_info.yml
+++ b/set_info.yml
@@ -63,3 +63,63 @@ fullSpoil: false
 #   additionalCardNames: []
 #   mtgsurl: "?"
 #   mtgscardpath: "?"
+---
+code: "?"
+name: "Iconic Masters"
+block: "?"
+size: ?
+releaseDate: "2017-11-17"
+type: "?"
+mtgsurl: "?"
+mtgscardpath: "?"
+fullSpoil: false
+---
+code: "?"
+name: "Unstable"
+block: "?"
+size: ?
+releaseDate: "2017-12-08"
+type: "?"
+mtgsurl: "?"
+mtgscardpath: "?"
+fullSpoil: false
+---
+code: "?"
+name: "Rivals of Ixalan"
+block: "Ixalan"
+size: ?
+releaseDate: "2018-01-19"
+type: "expansion"
+mtgsurl: "?"
+mtgscardpath: "?"
+fullSpoil: false
+---
+code: "?"
+name: "Masters 25"
+block: "?"
+size: ?
+releaseDate: "2018-03-16"
+type: "?"
+mtgsurl: "?"
+mtgscardpath: "?"
+fullSpoil: false
+---
+code: "?"
+name: "Dominaria"
+block: "?"
+size: ?
+releaseDate: "2018-04-27"
+type: "?"
+mtgsurl: "?"
+mtgscardpath: "?"
+fullSpoil: false
+---
+code: "?"
+name: "Core 2019"
+block: "?"
+size: ?
+releaseDate: "2018-07-20"
+type: "Core?"
+mtgsurl: "?"
+mtgscardpath: "?"
+fullSpoil: false

--- a/set_info.yml
+++ b/set_info.yml
@@ -85,6 +85,7 @@ type: "un"
 mtgsurl: ""
 #mtgscardpath: "?"
 fullSpoil: false
+noRSS: true
 ---
 code: "RIX"
 name: "Rivals of Ixalan"

--- a/set_info.yml
+++ b/set_info.yml
@@ -71,9 +71,10 @@ name: "Iconic Masters"
 #size: ?
 releaseDate: "2017-11-17"
 type: "masters"
-#mtgsurl: "?"
+mtgsurl: ""
 #mtgscardpath: "?"
 fullSpoil: false
+noRSS: true
 ---
 code: "UST"
 name: "Unstable"
@@ -81,7 +82,7 @@ name: "Unstable"
 #size: ?
 releaseDate: "2017-12-08"
 type: "un"
-#mtgsurl: "?"
+mtgsurl: ""
 #mtgscardpath: "?"
 fullSpoil: false
 ---
@@ -91,9 +92,10 @@ block: "Ixalan"
 #size: ?
 releaseDate: "2018-01-19"
 type: "expansion"
-#mtgsurl: "?"
+mtgsurl: ""
 #mtgscardpath: "?"
 fullSpoil: false
+noRSS: true
 ---
 code: "A25"
 name: "Masters 25"
@@ -101,9 +103,10 @@ name: "Masters 25"
 #size: ?
 releaseDate: "2018-03-16"
 type: "masters"
-#mtgsurl: "?"
+mtgsurl: ""
 #mtgscardpath: "?"
 fullSpoil: false
+noRSS: true
 ---
 code: "DOM"
 name: "Dominaria"
@@ -111,9 +114,10 @@ name: "Dominaria"
 #size: ?
 releaseDate: "2018-04-27"
 type: "expansion"
-#mtgsurl: "?"
+mtgsurl: ""
 #mtgscardpath: "?"
 fullSpoil: false
+noRSS: true
 ---
 code: "M19"
 name: "Core 2019"
@@ -121,6 +125,7 @@ name: "Core 2019"
 #size: ?
 releaseDate: "2018-07-20"
 type: "core"
-#mtgsurl: "?"
+mtgsurl: ""
 #mtgscardpath: "?"
 fullSpoil: false
+noRSS: true

--- a/set_info.yml
+++ b/set_info.yml
@@ -15,8 +15,12 @@
 # mtgsurl: "http://url_to_mtgsalvation.com/spoilers/page
 # mtgscardpath "http://url_to_mtgsalvation.com/cards/setpage/"
 # fullSpoil: false
+# noRSS: true                                                               #don't check MTGS spoiler newsfeed spoiler.rss for this set
+# noBooster: 
+# mythicCode: 
+# mythicOnly: 
+# scryfallOnly: 
 # masterpieces:
-# mythicCode:
 #
 # Masterpieces contain code, name, releaseDate as above
 # and requires mtgsurl and mtgscardpath
@@ -31,7 +35,7 @@
 # block: "Amonkhet"
 # size: 199
 # releaseDate: "2017-07-14"
-# type: "expansion"
+# type: "expansion"                                                          #can be "expansion", "core", "commander", "masters" - for full list see http://mtgjson.com/documentation.html#sets
 # mtgsurl: "http://www.mtgsalvation.com/spoilers/183-hour-of-devastation"    #looks like http://www.mtgsalvation.com/spoilers/183 automatically redirects to same page
 # mtgscardpath: "http://www.mtgsalvation.com/cards/hour-of-devastation/"     #important: don't forget the trailing slash "/" at the end of the link!
 # fullSpoil: false

--- a/set_info.yml
+++ b/set_info.yml
@@ -16,6 +16,7 @@
 # mtgscardpath "http://url_to_mtgsalvation.com/cards/setpage/"
 # fullSpoil: false
 # masterpieces:
+# mythicCode:
 #
 # Masterpieces contain code, name, releaseDate as above
 # and requires mtgsurl and mtgscardpath

--- a/set_info.yml
+++ b/set_info.yml
@@ -67,12 +67,12 @@ fullSpoil: false
 ---
 code: "IMA"
 name: "Iconic Masters"
-block: "?"
-size: ?
+#block: "?"
+#size: ?
 releaseDate: "2017-11-17"
 type: "masters"
-mtgsurl: "?"
-mtgscardpath: "?"
+#mtgsurl: "?"
+#mtgscardpath: "?"
 fullSpoil: false
 ---
 code: "UST"
@@ -88,11 +88,11 @@ fullSpoil: false
 code: "RIX"
 name: "Rivals of Ixalan"
 block: "Ixalan"
-size: ?
+#size: ?
 releaseDate: "2018-01-19"
 type: "expansion"
-mtgsurl: "?"
-mtgscardpath: "?"
+#mtgsurl: "?"
+#mtgscardpath: "?"
 fullSpoil: false
 ---
 code: "A25"

--- a/set_info.yml
+++ b/set_info.yml
@@ -65,27 +65,27 @@ fullSpoil: false
 #   mtgsurl: "?"
 #   mtgscardpath: "?"
 ---
-code: "?"
+code: "IMA"
 name: "Iconic Masters"
 block: "?"
 size: ?
 releaseDate: "2017-11-17"
-type: "?"
+type: "masters"
 mtgsurl: "?"
 mtgscardpath: "?"
 fullSpoil: false
 ---
-code: "?"
+code: "UST"
 name: "Unstable"
-block: "?"
-size: ?
+#block: "?"
+#size: ?
 releaseDate: "2017-12-08"
-type: "?"
-mtgsurl: "?"
-mtgscardpath: "?"
+type: "un"
+#mtgsurl: "?"
+#mtgscardpath: "?"
 fullSpoil: false
 ---
-code: "?"
+code: "RIX"
 name: "Rivals of Ixalan"
 block: "Ixalan"
 size: ?
@@ -95,32 +95,32 @@ mtgsurl: "?"
 mtgscardpath: "?"
 fullSpoil: false
 ---
-code: "?"
+code: "A25"
 name: "Masters 25"
-block: "?"
-size: ?
+#block: "?"
+#size: ?
 releaseDate: "2018-03-16"
-type: "?"
-mtgsurl: "?"
-mtgscardpath: "?"
+type: "masters"
+#mtgsurl: "?"
+#mtgscardpath: "?"
 fullSpoil: false
 ---
-code: "?"
+code: "DOM"
 name: "Dominaria"
-block: "?"
-size: ?
+#block: "?"
+#size: ?
 releaseDate: "2018-04-27"
-type: "?"
-mtgsurl: "?"
-mtgscardpath: "?"
+type: "expansion"
+#mtgsurl: "?"
+#mtgscardpath: "?"
 fullSpoil: false
 ---
-code: "?"
+code: "M19"
 name: "Core 2019"
-block: "?"
-size: ?
+#block: "?"
+#size: ?
 releaseDate: "2018-07-20"
-type: "Core?"
-mtgsurl: "?"
-mtgscardpath: "?"
+type: "core"
+#mtgsurl: "?"
+#mtgscardpath: "?"
 fullSpoil: false

--- a/spoilers.py
+++ b/spoilers.py
@@ -631,13 +631,13 @@ def write_combined_xml(mtgjson, setinfos):
             cardsxml.write("</card>\n")
 
     cardsxml.write("</cards>\n</cockatrice_carddatabase>")
-
-    print 'XML COMBINED STATS'
-    print 'Total cards: ' + str(count)
-    if dfccount > 0:
-        print 'DFC: ' + str(dfccount)
-    print 'Newest: ' + str(newest)
-    print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
+    if count > 0:
+        print 'XML COMBINED STATS'
+        print 'Total cards: ' + str(count)
+        if dfccount > 0:
+            print 'DFC: ' + str(dfccount)
+        print 'Newest: ' + str(newest)
+        print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
 
 
 def pretty_xml(infile):

--- a/spoilers.py
+++ b/spoilers.py
@@ -491,6 +491,8 @@ def write_xml(mtgjson, code, name, releaseDate):
             print 'DFC: ' + str(dfccount)
         print 'Newest: ' + str(newest)
         print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
+    else:
+        print 'Set ' + code + ' has no spoiled cards.'
 
 
 def write_combined_xml(mtgjson, setinfos):

--- a/spoilers.py
+++ b/spoilers.py
@@ -484,12 +484,13 @@ def write_xml(mtgjson, code, name, releaseDate):
 
     cardsxml.write("</cards>\n</cockatrice_carddatabase>")
 
-    print 'XML Stats for ' + code
-    print 'Total cards: ' + str(count)
-    if dfccount > 0:
-        print 'DFC: ' + str(dfccount)
-    print 'Newest: ' + str(newest)
-    print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
+    if count > 0:
+        print 'XML Stats for ' + code
+        print 'Total cards: ' + str(count)
+        if dfccount > 0:
+            print 'DFC: ' + str(dfccount)
+        print 'Newest: ' + str(newest)
+        print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
 
 
 def write_combined_xml(mtgjson, setinfos):
@@ -631,13 +632,13 @@ def write_combined_xml(mtgjson, setinfos):
             cardsxml.write("</card>\n")
 
     cardsxml.write("</cards>\n</cockatrice_carddatabase>")
-    if count > 0:
-        print 'XML COMBINED STATS'
-        print 'Total cards: ' + str(count)
-        if dfccount > 0:
-            print 'DFC: ' + str(dfccount)
-        print 'Newest: ' + str(newest)
-        print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
+    
+    print 'XML COMBINED STATS'
+    print 'Total cards: ' + str(count)
+    if dfccount > 0:
+        print 'DFC: ' + str(dfccount)
+    print 'Newest: ' + str(newest)
+    print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
 
 
 def pretty_xml(infile):


### PR DESCRIPTION
Not all set information available that early for sure.
Cut back on debug log for sets without any spoiled cards.
This PR also extends the in-file documentation a bit.

Sources:
- http://www.mtgsalvation.com/forums/magic-fundamentals/the-rumor-mill/673776-schedule-of-upcoming-releases-and-spoiler-seasons
- http://magic.wizards.com/en/products/iconic-masters
- http://markrosewater.tumblr.com/post/163779974563/wait-so-the-unstable-set-code-is-ust-i-thought
- http://magic.wizards.com/en/products/rivals-ixalan
- http://magic.wizards.com/en/products/masters-25
- http://magic.wizards.com/en/products/dominaria
- http://magic.wizards.com/en/products/core-2019