### PR TITLE
print running hint in travis log

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -5,6 +5,7 @@ SOURCE_BRANCH="master"
 TARGET_BRANCH="files"
 
 function doCompile {
+    echo "Running script..."
     python main.py dumpXML=True
 }
 
@@ -12,7 +13,6 @@ function doCompile {
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
     echo "Skipping deploy; just doing a build."
     # Run our compile script and let user know in logs
-    echo "Running script..."
     doCompile
     exit 0
 fi
@@ -33,7 +33,6 @@ cd ..
 rm -rf out/**/* || exit 0
 
 # Run our compile script and let user know in logs
-echo "Running script..."
 doCompile
 
 echo TRAVIS_PULL_REQUEST ${TRAVIS_PULL_REQUEST}

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -30,7 +30,8 @@ cd ..
 # Clean out existing contents
 rm -rf out/**/* || exit 0
 
-# Run our compile script
+# Run our compile script and let user know in logs
+echo "Running script..."
 doCompile
 
 echo TRAVIS_PULL_REQUEST ${TRAVIS_PULL_REQUEST}

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -11,6 +11,8 @@ function doCompile {
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
     echo "Skipping deploy; just doing a build."
+    # Run our compile script and let user know in logs
+    echo "Running script..."
     doCompile
     exit 0
 fi


### PR DESCRIPTION
Instead of stopping at "Branch files set up to track remote branch files from origin." (run from master)
or "Skipping deploy; just doing a build." (run from other branches/pr's) for 2-3 minutes, we tell the log observer that something is actually happening and all is ok.

If you want to move that to the start of main.py instead and make it available for local runs, that would be very cool as well! @dev-id 