### PR TITLE
remove unneeded time stamp in console log

### DIFF
--- a/spoilers.py
+++ b/spoilers.py
@@ -540,7 +540,7 @@ def write_xml(mtgjson, code, name, releaseDate):
         if dfccount > 0:
             print 'DFC: ' + str(dfccount)
         print 'Newest: ' + str(newest)
-        print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
+        print 'Run @ ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
     else:
         print 'Set ' + code + ' has no spoiled cards.'
 
@@ -690,7 +690,7 @@ def write_combined_xml(mtgjson, setinfos):
     if dfccount > 0:
         print 'DFC: ' + str(dfccount)
     print 'Newest: ' + str(newest)
-    print 'Runtime: ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
+    print 'Run @ ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
 
 
 def pretty_xml(infile):

--- a/spoilers.py
+++ b/spoilers.py
@@ -540,7 +540,6 @@ def write_xml(mtgjson, code, name, releaseDate):
         if dfccount > 0:
             print 'DFC: ' + str(dfccount)
         print 'Newest: ' + str(newest)
-        print 'Run @ ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
     else:
         print 'Set ' + code + ' has no spoiled cards.'
 
@@ -690,7 +689,6 @@ def write_combined_xml(mtgjson, setinfos):
     if dfccount > 0:
         print 'DFC: ' + str(dfccount)
     print 'Newest: ' + str(newest)
-    print 'Run @ ' + str(datetime.datetime.today().strftime('%H:%M')) + ' (UTC) on ' + str(datetime.date.today())
 
 
 def pretty_xml(infile):


### PR DESCRIPTION
~~`Runtime` could be a time frame as well, not necessary a fixed time stamp.~~

--> Remove phrasing completely 👍 