### PR TITLE
readme: add spoiler content badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fgithub.com%2FCockatrice%2FMagic-Spoiler%2Fblob%2Ffiles%2Fspoiler.json)
+
 # Magic-Spoiler [![Gitter Chat](https://img.shields.io/gitter/room/Cockatrice/Magic-Spoiler.svg)](https://gitter.im/Cockatrice/Magic-Spoiler) #
 
 Magic-Spoiler is a Python script to scrape <i>MTG Salvation</i>, <i>Scryfall</i>, <i>MythicSpoiler</i> and <i>Wizards</i> to compile<br>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fgithub.com%2FCockatrice%2FMagic-Spoiler%2Fblob%2Ffiles%2Fspoiler.json)
+[![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fgithub.com%2FCockatrice%2FMagic-Spoiler%2Fblob%2Ffiles%2Fspoiler.json)](https://github.com/Cockatrice/Magic-Spoiler/blob/files/spoiler.xml)
 
 # Magic-Spoiler [![Gitter Chat](https://img.shields.io/gitter/room/Cockatrice/Magic-Spoiler.svg)](https://gitter.im/Cockatrice/Magic-Spoiler) #
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fgithub.com%2FCockatrice%2FMagic-Spoiler%2Fblob%2Ffiles%2Fspoiler.json)](https://github.com/Cockatrice/Magic-Spoiler/blob/files/spoiler.xml)
+[![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fraw.githubusercontent.com%2FCockatrice%2FMagic-Spoiler%2Ffiles%2Fspoiler.json)](https://github.com/Cockatrice/Magic-Spoiler/blob/files/spoiler.xml)
+
 
 # Magic-Spoiler [![Gitter Chat](https://img.shields.io/gitter/room/Cockatrice/Magic-Spoiler.svg)](https://gitter.im/Cockatrice/Magic-Spoiler) #
 


### PR DESCRIPTION
Dynamic badge which pulls data from our own `spoiler.json` file in the `files` branch.
Displays `name` of available sets in our file.

For a former [spoiler.json file](https://github.com/Cockatrice/Magic-Spoiler/blob/07f6dad1f96034df67667af0ca9873f20e87a064/spoiler.json) with two sets at a time it'll produce this:
![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fraw.githubusercontent.com%2FCockatrice%2FMagic-Spoiler%2F07f6dad1f96034df67667af0ca9873f20e87a064%2Fspoiler.json)

Right now it would display this for the [spoiler.json at master](https://github.com/Cockatrice/Magic-Spoiler/blob/files/spoiler.json):
![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fraw.githubusercontent.com%2FCockatrice%2FMagic-Spoiler%2Ffiles%2Fspoiler.json)

<br>

As long as the linked spoiler.json file doesn't exist or can't be accessed it'll return `inaccessible`, so we know there is a problem with the file output:
![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fwrong.url.com%2FCockatrice%2FMagic-Spoiler%2F07f6dad1f96034df67667af0ca9873f20e87a064%2Fspoiler.json)

As long as [spoiler.json](https://github.com/Cockatrice/Magic-Spoiler/blob/229c5471478fbad68087f6a9ed58aa1f4893541e/spoiler.json) is empty (during off-season), it'll display `no result`:
![](https://img.shields.io/badge/dynamic/json.svg?label=currently%20included%20sets&colorB=4ac41d&query=$.*.name&uri=https%3A%2F%2Fraw.githubusercontent.com%2FCockatrice%2FMagic-Spoiler%2F229c5471478fbad68087f6a9ed58aa1f4893541e%2Fspoiler.json)
