### PR TITLE
fix #240: use set_type from scryfall api

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -206,9 +206,10 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
     :param set_obj: Set object
     """
     card_xml_file.write(
-        "<set>\n<name>" + set_obj["code"] + "</name>\n"
+        "<set>\n"
+        "<name>" + set_obj["code"] + "</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
-        "<settype>" + set_obj["set_type"].capitalize() + "</settype>\n"
+        "<settype>" + set_obj["set_type"] + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
         "</set>\n"
     )

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -208,7 +208,7 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
     card_xml_file.write(
         "<set>\n<name>" + set_obj["code"] + "</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
-        "<settype>" + set_obj["set_type"] + "</settype>\n"
+        "<settype>" + set_obj["set_type"].capitalize() + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
         "</set>\n"
     )

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -206,10 +206,9 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
     :param set_obj: Set object
     """
     card_xml_file.write(
-        "<set>\n"
-        "<name>" + set_obj["code"] + "</name>\n"
+        "<set>\n<name>" + set_obj["code"] + "</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
-        "<settype>" + set_obj["set_type"] + "</settype>\n"
+        "<settype>" + set_obj["set_type"].capitalize() + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
         "</set>\n"
     )

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -208,7 +208,7 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
     card_xml_file.write(
         "<set>\n<name>" + set_obj["code"] + "</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
-        "<settype>Expansion</settype>\n"
+        "<settype>" + set_obj["set_type"] + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
         "</set>\n"
     )


### PR DESCRIPTION
No idea if I can use `capitalize()` like that.
I can simply remove it - still better than hard coding `Expansion` as set type all the time.

Not tested as Travis doesn't work on PR's with our code in this repo. (https://github.com/Cockatrice/Magic-Spoiler/issues/236)
Also, there is no xml dump option anymore to verify the output in the Travis logs.