### PR TITLE
fix #87: add spoiler tag to meta data

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -209,7 +209,7 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
         "<set>\n"
         "<name>" + set_obj["code"] + " (Spoiler)</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
-        "<settype>Expansion</settype>\n"
+        "<settype>" + set_obj["set_type"].capitalize() + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
         "</set>\n"
     )

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -206,7 +206,8 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
     :param set_obj: Set object
     """
     card_xml_file.write(
-        "<set>\n<name>" + set_obj["code"] + "</name>\n"
+        "<set>\n"
+        "<name>" + set_obj["code"] + " (Spoiler)</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
         "<settype>Expansion</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"


### PR DESCRIPTION
Cockatrice would display the information at relevant places:
![](https://user-images.githubusercontent.com/9874850/34921669-e6faef34-f985-11e7-936f-5e114761fa19.png)
![34921691-1639ac90-f986-11e7-820e-57fe2e4942ad](https://user-images.githubusercontent.com/9874850/60263125-273e4780-98e0-11e9-94b6-616395176fca.png)
