### PR TITLE
set_type: improved handling

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -209,7 +209,7 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
         "<set>\n"
         "<name>" + set_obj["code"] + " (Spoiler)</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
-        "<settype>" + set_obj["set_type"].capitalize() + "</settype>\n"
+        "<settype>" + set_obj["set_type"].replace("_"," ").title() + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
         "</set>\n"
     )

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -209,7 +209,7 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
         "<set>\n"
         "<name>" + set_obj["code"] + " (Spoiler)</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
-        "<settype>Expansion</settype>\n"
+        "<settype>" + set_obj["set_type"].capitalize() + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
         "</set>\n"
     )

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -206,7 +206,8 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
     :param set_obj: Set object
     """
     card_xml_file.write(
-        "<set>\n<name>" + set_obj["code"] + "</name>\n"
+        "<set>\n"
+        "<name>" + set_obj["code"] + " (Spoiler)</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
         "<settype>Expansion</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -206,8 +206,7 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
     :param set_obj: Set object
     """
     card_xml_file.write(
-        "<set>\n"
-        "<name>" + set_obj["code"] + " (Spoiler)</name>\n"
+        "<set>\n<name>" + set_obj["code"] + "</name>\n"
         "<longname>" + set_obj["name"] + "</longname>\n"
         "<settype>" + set_obj["set_type"].replace("_"," ").title() + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"


### PR DESCRIPTION
This is an improved version of #241.

What this does additinally:

- replaces `_` with spaces
- capitalizes the first letter of every word

So no more `Dual_deck` out of `duel_deck`, but `Duel Deck`