### PR TITLE
Add cardcount property to each set

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -210,6 +210,7 @@ def fill_header_sets(card_xml_file: IO[Any], set_obj: Dict[str, str]) -> None:
         "<longname>" + set_obj["name"] + "</longname>\n"
         "<settype>" + set_obj["set_type"].replace("_"," ").title() + "</settype>\n"
         "<releasedate>" + set_obj["released_at"] + "</releasedate>\n"
+        "<cardcount>" + set_obj["card_count"].__str__() + "</cardcount>\n"
         "</set>\n"
     )
 


### PR DESCRIPTION
Related #218

Scryfall API holds data about the amount of currently spoiled cards.
This PR adds that information to each set and makes a nice overview of the file content.

While this is not a known propety by Cockatrice, it still loads and display the file correctly:
`[CockatriceXml3Parser] Unknown set property "cardcount" , trying to continue anyway`