### PR TITLE
Move to Cockatrice v4 db style

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -347,8 +347,33 @@ def write_cards(
             xml_escape,
             [set_name, mana_cost, card_cmc, card_type, pow_tough, table_row, text],
         )
+
         card_xml_file.write("<card>\n")
+
         card_xml_file.write("<name>" + set_name + "</name>\n")
+
+        card_xml_file.write("<text>" + text + "</text>\n")
+
+        card_xml_file.write("<prop>\n")
+
+        if "colors" in card.keys():
+            for color in card["colors"]:
+                card_xml_file.write("<color>" + str(color) + "</color>\n")
+
+        card_xml_file.write("<type>" + card_type + "</type>\n")
+
+        card_xml_file.write("<cmc>" + card_cmc + "</cmc>\n")
+
+        if pow_tough:
+            card_xml_file.write("<pt>" + pow_tough + "</pt>\n")
+
+        card_xml_file.write("<manacost>" + mana_cost + "</manacost>\n")
+
+        if "loyalty" in card.keys():
+            card_xml_file.write("<loyalty>" + str(card["loyalty"]) + "</loyalty>\n")
+
+        card_xml_file.write("</prop>\n")
+        
         card_xml_file.write(
             '<set rarity="'
             + str(card["rarity"])
@@ -358,25 +383,12 @@ def write_cards(
             + str(set_code)
             + "</set>\n"
         )
-        card_xml_file.write("<manacost>" + mana_cost + "</manacost>\n")
-        card_xml_file.write("<cmc>" + card_cmc + "</cmc>\n")
-
-        if "colors" in card.keys():
-            for color in card["colors"]:
-                card_xml_file.write("<color>" + str(color) + "</color>\n")
 
         if set_name + " enters the battlefield tapped" in text:
             card_xml_file.write("<cipt>1</cipt>\n")
 
-        card_xml_file.write("<type>" + card_type + "</type>\n")
-
-        if pow_tough:
-            card_xml_file.write("<pt>" + pow_tough + "</pt>\n")
-
-        if "loyalty" in card.keys():
-            card_xml_file.write("<loyalty>" + str(card["loyalty"]) + "</loyalty>\n")
         card_xml_file.write("<tablerow>" + table_row + "</tablerow>\n")
-        card_xml_file.write("<text>" + text + "</text>\n")
+
         card_xml_file.write("</card>\n")
 
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -208,7 +208,7 @@ def open_header(card_xml_file: IO[Any]) -> None:
     :param card_xml_file: Card file path
     """
     card_xml_file.write(
-        "<cockatrice_carddatabase version='3'>\n"
+        "<cockatrice_carddatabase version='4'>\n"
         + "  <!--\n"
         + "  Created At: "
         + datetime.datetime.utcnow().strftime("%a, %b %d %Y, %H:%M:%S")

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -295,6 +295,11 @@ def write_cards(
         else:
             pow_tough = ""
 
+        if "loyalty" in card.keys() and card["loyalty"]:
+            loyalty = str(card["loyalty"])
+        else:
+            loyalty = ""
+
         if "text" in card.keys():
             text = card["text"]
         else:
@@ -343,37 +348,28 @@ def write_cards(
                     if card["layout"] == "split" or card["layout"] == "aftermath":
                         continue
 
-        set_name, mana_cost, card_cmc, card_type, pow_tough, table_row, text = map(
+        set_name, mana_cost, card_cmc, card_type, pow_tough, table_row, text, loyalty = map(
             xml_escape,
-            [set_name, mana_cost, card_cmc, card_type, pow_tough, table_row, text],
+            [set_name, mana_cost, card_cmc, card_type, pow_tough, table_row, text, loyalty],
         )
-
         card_xml_file.write("<card>\n")
-
         card_xml_file.write("<name>" + set_name + "</name>\n")
-
         card_xml_file.write("<text>" + text + "</text>\n")
-
         card_xml_file.write("<prop>\n")
-
         if "colors" in card.keys():
             for color in card["colors"]:
                 card_xml_file.write("<color>" + str(color) + "</color>\n")
 
         card_xml_file.write("<type>" + card_type + "</type>\n")
-
         card_xml_file.write("<cmc>" + card_cmc + "</cmc>\n")
-
+        card_xml_file.write("<manacost>" + mana_cost + "</manacost>\n")
         if pow_tough:
             card_xml_file.write("<pt>" + pow_tough + "</pt>\n")
 
-        card_xml_file.write("<manacost>" + mana_cost + "</manacost>\n")
-
-        if "loyalty" in card.keys():
-            card_xml_file.write("<loyalty>" + str(card["loyalty"]) + "</loyalty>\n")
+        if loyalty:
+            card_xml_file.write("<loyalty>" + loyalty + "</loyalty>\n")
 
         card_xml_file.write("</prop>\n")
-        
         card_xml_file.write(
             '<set rarity="'
             + str(card["rarity"])
@@ -383,12 +379,10 @@ def write_cards(
             + str(set_code)
             + "</set>\n"
         )
-
         if set_name + " enters the battlefield tapped" in text:
             card_xml_file.write("<cipt>1</cipt>\n")
 
         card_xml_file.write("<tablerow>" + table_row + "</tablerow>\n")
-
         card_xml_file.write("</card>\n")
 
 


### PR DESCRIPTION
Fixes https://github.com/Cockatrice/Magic-Spoiler/issues/232

As introduced in Cockatrice/Cockatrice#3511, there is now a "properties" hashmap holding game-specific fields:
```
<card>
    <name>Mournful Kitten</name>
    <text>Every time you stomp on Mournful Kitten, it meows.</text>
    <prop>
        <side>front</side>
        <maintype>Creature</maintype>
        <colors>G</colors>
        <layout>normal</layout>
        <manacost>1G</manacost>
        <cmc>2</cmc>
        <type>Creature</type>
    </prop>
    <set muid="1234" rarity="common" num="85" uuid="c11eb854-4c03-4abd-aaf1-9718608a34b3">KWU</set>
    <set muid="1235" rarity="common" num="18" uuid="c3f048d9-ca13-485d-ad92-de4695b7dc18">KKK</set>
    <tablerow>1</tablerow>
</card>
```

---

Example:
- taken from current v3: https://github.com/Cockatrice/Magic-Spoiler/blob/ddba2b9efc5813593f1f85e73523cb33999d7149/spoiler.xml#L29-L39
```
    <card>
      <name>Chalice of the Void</name>
      <set rarity="Mythic Rare" picURL="https://c1.scryfall.com/file/scryfall-cards/normal/front/2/5/25674e46-e15b-4fc0-9813-39b4e1c23de4.jpg">TSR</set>
      <manacost>XX</manacost>
      <cmc>0.0</cmc>
      <type>Artifact</type>
      <loyalty>None</loyalty>
      <tablerow>1</tablerow>
      <text>Chalice of the Void enters the battlefield with X charge counters on it.
Whenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.</text>
    </card>
```

- should look like this in new v4:
```
    <card>
      <name>Chalice of the Void</name>
      <text>Chalice of the Void enters the battlefield with X charge counters on it.
Whenever a player casts a spell with converted mana cost equal to the number of charge counters on Chalice of the Void, counter that spell.</text>
      <prop>
        <type>Artifact</type>
        <cmc>0.0</cmc>
        <manacost>XX</manacost>
        <loyalty>None</loyalty>
      </prop>
      <set rarity="Mythic Rare" picURL="https://c1.scryfall.com/file/scryfall-cards/normal/front/2/5/25674e46-e15b-4fc0-9813-39b4e1c23de4.jpg">TSR</set>
      <tablerow>1</tablerow>
    </card>
```

---

Looks like we never cared about `<side>`, `<maintype>`, `<coloridentity>`, `<layout>` or other for xml spoiler files? The json misses some, too. [See the docs in the Wiki](https://github.com/Cockatrice/Cockatrice/wiki/Custom-Cards-&-Sets#to-add-your-own-custom-cards-follow-these-steps).