### PR TITLE
Adapt script to require UTF-8

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -389,7 +389,7 @@ def write_spoilers_xml(trice_dicts: Dict[str, List[Dict[str, Any]]]) -> bool:
     output_file_name = "spoiler.xml"
 
     pathlib.Path("out").mkdir(parents=True, exist_ok=True)
-    card_xml_file = OUTPUT_TMP_DIR.joinpath(output_file_name).open("w")
+    card_xml_file = OUTPUT_TMP_DIR.joinpath(output_file_name).open("w", encoding="utf-8")
 
     # Fill in set headers
     open_header(card_xml_file)
@@ -429,7 +429,7 @@ def write_spoilers_json(trice_dicts: Dict[str, List[Dict[str, Any]]]) -> bool:
     output_file_path = OUTPUT_TMP_DIR.joinpath("spoiler.json")
 
     OUTPUT_TMP_DIR.mkdir(parents=True, exist_ok=True)
-    with output_file_path.open("w") as f:
+    with output_file_path.open("w", encoding="utf-8") as f:
         json.dump(trice_dicts, f, sort_keys=True, indent=4)
 
     # If content didn't change, discard newest creation
@@ -456,8 +456,8 @@ def compare_json_content(f1: str, f2: str) -> bool:
     file2 = pathlib.Path(f2)
 
     if file1.is_file() and file2.is_file():
-        f1_hash = hashlib.sha512(file1.open("r").read().encode()).hexdigest()
-        f2_hash = hashlib.sha512(file2.open("r").read().encode()).hexdigest()
+        f1_hash = hashlib.sha512(file1.open("rb").read().encode()).hexdigest()
+        f2_hash = hashlib.sha512(file2.open("rb").read().encode()).hexdigest()
 
         return f1_hash == f2_hash
 
@@ -502,7 +502,9 @@ def write_set_xml(trice_dict: List[Dict[str, Any]], set_obj: Dict[str, str]) -> 
         return False
 
     OUTPUT_TMP_DIR.mkdir(parents=True, exist_ok=True)
-    card_xml_file = OUTPUT_TMP_DIR.joinpath("{}.xml".format(set_obj["code"])).open("w")
+    set_code = set_obj["code"]
+    file_path = OUTPUT_TMP_DIR.joinpath(f"{set_code}.xml")
+    card_xml_file = file_path.open("w", encoding="utf-8")
 
     open_header(card_xml_file)
     fill_header_sets(card_xml_file, set_obj)
@@ -539,7 +541,7 @@ def write_set_json(trice_dict: List[Dict[str, Any]], set_obj: Dict[str, str]) ->
     output_file_path = OUTPUT_TMP_DIR.joinpath("{}.json".format(set_obj["code"]))
 
     OUTPUT_TMP_DIR.mkdir(parents=True, exist_ok=True)
-    with output_file_path.open("w") as f:
+    with output_file_path.open("w", encoding="utf-8") as f:
         json.dump(trice_dict, f, sort_keys=True, indent=4)
 
     # If content didn't change, discard newest creation
@@ -604,10 +606,11 @@ def delete_old_files() -> bool:
     if OUTPUT_TMP_DIR.is_dir():
         shutil.rmtree(OUTPUT_TMP_DIR)
 
+    enabled_path = OUTPUT_DIR.joinpath("SpoilerSeasonEnabled")
     if not SPOILER_SETS.get():
-        OUTPUT_DIR.joinpath("SpoilerSeasonEnabled").unlink(missing_ok=True)
+        enabled_path.unlink(missing_ok=True)
     else:
-        OUTPUT_DIR.joinpath("SpoilerSeasonEnabled").open("w").write(" ")
+        enabled_path.open("w", encoding="utf-8").write(" ")
 
     return deleted
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -456,7 +456,6 @@ def compare_json_content(f1: str, f2: str) -> bool:
     file2 = pathlib.Path(f2)
 
     if file1.is_file() and file2.is_file():
-        f1_hash = hashlib.sha512(file1.open("rb").read().encode()).hexdigest()
         f1_hash = hashlib.sha512(file1.open("rb").read()).hexdigest()
         f2_hash = hashlib.sha512(file2.open("rb").read()).hexdigest()
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -457,7 +457,8 @@ def compare_json_content(f1: str, f2: str) -> bool:
 
     if file1.is_file() and file2.is_file():
         f1_hash = hashlib.sha512(file1.open("rb").read().encode()).hexdigest()
-        f2_hash = hashlib.sha512(file2.open("rb").read().encode()).hexdigest()
+        f1_hash = hashlib.sha512(file1.open("rb").read()).hexdigest()
+        f2_hash = hashlib.sha512(file2.open("rb").read()).hexdigest()
 
         return f1_hash == f2_hash
 


### PR DESCRIPTION
Fixes #253

As the python docs state:
>Windows still uses legacy encodings for the system encoding (the ANSI Code Page). Python uses it for the default encoding of text files (e.g. locale.getpreferredencoding()).
>
>This may cause issues because UTF-8 is widely used on the internet and most Unix systems


Running `python -m magic_spoiler` always stops with:~~
`UnicodeEncodeError: 'charmap' codec can't encode character '\u2212' in position 63: character maps to <undefined>`

Setting UTF-8 mode solves the issue on Windows for me.

---

**Update:**
See https://github.com/Cockatrice/Magic-Spoiler/pull/267#issuecomment-893058500, @ebbit1q changed the script to prevent Windows users to run into encoding issues.
Obviously it's the way better solution to fix it for the users instead telling them that they have to run the script in a certain mode. 👍 