### PR TITLE
Only print loyalty when relevant

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -370,7 +370,7 @@ def write_cards(
         if pow_tough:
             card_xml_file.write("<pt>" + pow_tough + "</pt>\n")
 
-        if "loyalty" in card.keys():
+        if str(card.get("loyalty")) != "None":
             card_xml_file.write("<loyalty>" + str(card["loyalty"]) + "</loyalty>\n")
         card_xml_file.write("<tablerow>" + table_row + "</tablerow>\n")
         card_xml_file.write("<text>" + text + "</text>\n")


### PR DESCRIPTION
Fixes #256

Stop writing `<loyalty>None</loyalty>` values to the spoiler file.

Please double check this. Results are looking fine to me.