### PR TITLE
use tilde (`~`) as the SPOILER_MARKER instead

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -17,7 +17,7 @@ from lxml import etree
 SCRYFALL_SET_URL: str = "https://api.scryfall.com/sets/{}"
 SESSION: contextvars.ContextVar = contextvars.ContextVar("SESSION_SCRYFALL")
 SPOILER_SETS: contextvars.ContextVar = contextvars.ContextVar("SPOILER_SETS")
-SPOILER_MARK = "*"
+SPOILER_MARK = "~"
 
 OUTPUT_DIR = pathlib.Path("out")
 OUTPUT_TMP_DIR = OUTPUT_DIR.joinpath("tmp")


### PR DESCRIPTION
`*` is apparently not allowed as a filename on windows