### PR TITLE
CI: upload artifacts for easy reviewing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Checkout output branch
-        if: env.DEPLOY == 'true'
+        # Run only when triggered from master or a PR
+        if: env.DEPLOY == 'true' || ${{github.event}} == 'pull_request'
         uses: actions/checkout@v2
         with:
           ref: files
@@ -53,7 +54,7 @@ jobs:
         run: python3 -m magic_spoiler
 
       - name: Upload artifacts
-        # Run only when not triggered from master (=PR's)
+        # Run only when triggered from a PR
         # if: env.DEPLOY == 'false'
         if: ${{github.event}} == 'pull_request'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,11 +54,12 @@ jobs:
 
       - name: Upload artifacts
         # Run only when not triggered from master (=PR's)
-        if: env.DEPLOY == 'false'
+        # if: env.DEPLOY == 'false'
+        if: ${{github.event}} == 'pull_request'
         uses: actions/upload-artifact@v2
         with:
           # name: 
-          path: .${{env.OUTPUT_PATH}}
+          path: ${{github.workspace}}/env.OUTPUT_PATH
           if-no-files-found: error
 
       - name: Deploy changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,8 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    # Every 6 hours = 4 times a day
-    - cron: '0 */6 * * *'
+    # Every 8 hours = 3 times a day
+    - cron: '0 */8 * * *'
 
 jobs:
   deploy:
@@ -25,6 +25,7 @@ jobs:
 
     env:
       DEPLOY: ${{github.ref == 'refs/heads/master'}}
+      # ARTIFACTS: ${{github.event == 'pull_request'}}
       OUTPUT_PATH: out
 
     steps:
@@ -32,8 +33,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Checkout output branch
-        # Run only when triggered from master or a PR
-        if: env.DEPLOY == 'true' || ${{github.event}} == 'pull_request'
+        # Run only when triggered from master
+        if: env.DEPLOY == 'true'
         uses: actions/checkout@v2
         with:
           ref: files
@@ -56,11 +57,12 @@ jobs:
       - name: Upload artifacts
         # Run only when triggered from a PR
         # if: env.DEPLOY == 'false'
+        # if: env.ARTIFACTS == 'true'
         if: ${{github.event}} == 'pull_request'
         uses: actions/upload-artifact@v2
         with:
           # name: 
-          path: ${{github.workspace}}/{{env.OUTPUT_PATH}}
+          path: ${{github.workspace}}/${{env.OUTPUT_PATH}}
           if-no-files-found: error
 
       - name: Deploy changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,18 @@ jobs:
         shell: bash
         run: python3 -m magic_spoiler
 
+      - name: Upload artifacts
+        # Run only when not triggered from master (=PR's)
+        # if: env.DEPLOY == 'false'
+        if: ${{github.event == 'pull_request'}}
+        uses: actions/upload-artifact@v2
+        with:
+          # name: 
+          path: .${{env.OUTPUT_PATH}}
+          if-no-files-found: error
+
       - name: Deploy changes
+        # Run only when triggered from master and changes are available
         if: env.DEPLOY == 'true' && steps.run.outputs.deploy == 'true'
         shell: bash
         working-directory: ${{env.OUTPUT_PATH}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,12 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    # every 6 hours = 4 times a day
+    # Every 6 hours = 4 times a day
     - cron: '0 */6 * * *'
 
 jobs:
   deploy:
-    # do not run the sheduled run on forks
+    # Do not run the scheduled workflow on forks
     if: github.event != 'schedule' || github.repository_owner == 'Cockatrice'
 
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           # name: 
-          path: ${{github.workspace}}/env.OUTPUT_PATH
+          path: ${{github.workspace}}/{{env.OUTPUT_PATH}}
           if-no-files-found: error
 
       - name: Deploy changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           # name: 
-          path: ${{github.workspace}}/${{env.OUTPUT_PATH}}
+          path: ${{github.workspace}}/${{env.OUTPUT_PATH}}/spoiler.xml
           if-no-files-found: error
 
       - name: Deploy changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,6 @@ jobs:
 
     env:
       DEPLOY: ${{github.ref == 'refs/heads/master'}}
-      # ARTIFACTS: ${{github.event == 'pull_request'}}
       OUTPUT_PATH: out
 
     steps:
@@ -56,13 +55,11 @@ jobs:
 
       - name: Upload artifacts
         # Run only when triggered from a PR
-        # if: env.DEPLOY == 'false'
-        # if: env.ARTIFACTS == 'true'
         if: ${{github.event}} == 'pull_request'
         uses: actions/upload-artifact@v2
         with:
-          # name: 
-          path: ${{github.workspace}}/${{env.OUTPUT_PATH}}/spoiler.xml
+          name: spoiler-output
+          path: ${{github.workspace}}/${{env.OUTPUT_PATH}}
           if-no-files-found: error
 
       - name: Deploy changes

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,7 @@ jobs:
 
       - name: Upload artifacts
         # Run only when not triggered from master (=PR's)
-        # if: env.DEPLOY == 'false'
-        if: ${{github.event == 'pull_request'}}
+        if: env.DEPLOY == 'false'
         uses: actions/upload-artifact@v2
         with:
           # name: 


### PR DESCRIPTION
This uploads the produced output as artifacts to the GitHub Action workflow (only for PR's!):

![spoiler-out](https://user-images.githubusercontent.com/9874850/125811654-066df8ff-1fd4-44ce-9b8e-333a506e3958.png)

<br>

I also lowered the scheduled builds from 4 per day to 3 to stress everybody involved a bit less. Felt like the result would be basically the same.