### PR TITLE
Add XML declaration

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -209,7 +209,7 @@ def open_header(card_xml_file: IO[Any]) -> None:
     """
     card_xml_file.write(
         "<?xml version='1.0' encoding='UTF-8'?>\n"
-        "<cockatrice_carddatabase version='3'>\n"
+        + "<cockatrice_carddatabase version='3'>\n"
         + "  <!--\n"
         + "  Created At: "
         + datetime.datetime.utcnow().strftime("%a, %b %d %Y, %H:%M:%S")

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -208,6 +208,7 @@ def open_header(card_xml_file: IO[Any]) -> None:
     :param card_xml_file: Card file path
     """
     card_xml_file.write(
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
         "<cockatrice_carddatabase version='3'>\n"
         + "  <!--\n"
         + "  Created At: "


### PR DESCRIPTION
Got removed in https://github.com/Cockatrice/Magic-Spoiler/commit/68c7150ac17e9f818703d434b5bf13f64842e537. Probably by mistake?

XML documents should start with a declaration.
