### PR TITLE
CI: Add link to deploy commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,3 +73,4 @@ jobs:
           git add -A .
           git commit -m "Deploy: $GITHUB_SHA"
           git push
+          echo "See deployment: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,4 +73,5 @@ jobs:
           git add -A .
           git commit -m "Deploy: $GITHUB_SHA"
           git push
-          echo "See deployment: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"
+          deploy_commit=`git rev-parse HEAD`
+          echo "See deployment: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$deploy_commit"


### PR DESCRIPTION
Quickly access and verify the changes made in the related deployment, instead only listing which files got changes in the `Run script` step and telling the count in the `Deploy changes` step:
![link](https://user-images.githubusercontent.com/9874850/126493337-d6b0ae5c-ae88-4476-b999-fc67a22ae999.png)

In the above example it should link to: https://github.com/Cockatrice/Magic-Spoiler/commit/9ace0ab72f42aefd26a573247f9fdbd5a7d55e13