### PR TITLE
CI: No new data found notice

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,4 +75,4 @@ jobs:
           git commit -m "Deploy: $GITHUB_SHA"
           git push
           deploy_commit=`git rev-parse HEAD`
-          echo ::notice::"See deployment: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$deploy_commit"
+          echo ::notice title=New data uploaded::"See deployment: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$deploy_commit"

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -644,7 +644,7 @@ def main() -> None:
     # Cleanup outdated stuff that's not necessary
     changed |= delete_old_files()
 
-    # Set output to deploy
+    # Only when run in CI, enable deployment on changes
     if os.environ['CI']:
         if changed:
             print("::set-output name=deploy::true")

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -408,7 +408,7 @@ def write_spoilers_xml(trice_dicts: Dict[str, List[Dict[str, Any]]]) -> bool:
 
     old_xml_location = str(OUTPUT_DIR.joinpath(output_file_name))
     if compare_xml_content(card_xml_file.name, old_xml_location):
-        print("No new data in spoiler.xml, skipping replacement")
+        print("::notice::No new data in spoiler.xml, skipping replacement")
         return False
 
     # Move new version to old location
@@ -646,9 +646,10 @@ def main() -> None:
     # Set output to deploy
     if changed:
         print("::set-output name=deploy::true")
+        print("::notice title=Updates available::New spoiler files will be uploaded")
     else:
         print("::set-output name=deploy::false")
-        print("::notice:: No new spoilers found")
+        print("::notice title=No updates available::There are no new spoiler cards")
 
 
 if __name__ == "__main__":

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -412,7 +412,7 @@ def write_spoilers_xml(trice_dicts: Dict[str, List[Dict[str, Any]]]) -> bool:
         return False
 
     # Move new version to old location
-    print("Changes detected, replacing spoiler.xml with updated version")
+    print("::notice::Changes detected, replacing spoiler.xml with updated version")
     shutil.move(card_xml_file.name, old_xml_location)
     return True
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -5,6 +5,7 @@ import contextvars
 import datetime
 import hashlib
 import json
+import os
 import pathlib
 import shutil
 import time
@@ -644,7 +645,7 @@ def main() -> None:
     changed |= delete_old_files()
 
     # Set output to deploy
-    if CI == true:
+    if os.environ('CI'):
         if changed:
             print("::set-output name=deploy::true")
             print("::notice title=Updates available::New spoiler files will be uploaded")

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -644,7 +644,7 @@ def main() -> None:
     changed |= delete_old_files()
 
     # Set output to deploy
-    if os.environ('CI'):
+    if CI == true:
         if changed:
             print("::set-output name=deploy::true")
             print("::notice title=Updates available::New spoiler files will be uploaded")

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -648,6 +648,7 @@ def main() -> None:
         print("::set-output name=deploy::true")
     else:
         print("::set-output name=deploy::false")
+        print("::notice:: No new spoilers found")
 
 
 if __name__ == "__main__":

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -644,7 +644,7 @@ def main() -> None:
     changed |= delete_old_files()
 
     # Set output to deploy
-    if os.getenv('CI'):
+    if os.environ('CI'):
         if changed:
             print("::set-output name=deploy::true")
             print("::notice title=Updates available::New spoiler files will be uploaded")

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -644,7 +644,7 @@ def main() -> None:
     changed |= delete_old_files()
 
     # Set output to deploy
-    if CI == true:
+    if os.getenv('CI'):
         if changed:
             print("::set-output name=deploy::true")
             print("::notice title=Updates available::New spoiler files will be uploaded")

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -5,7 +5,6 @@ import contextvars
 import datetime
 import hashlib
 import json
-import os
 import pathlib
 import shutil
 import time
@@ -644,13 +643,12 @@ def main() -> None:
     # Cleanup outdated stuff that's not necessary
     changed |= delete_old_files()
 
-    # Only when run in CI, enable deployment on changes
-    if os.environ['CI']:
-        if changed:
-            print("::set-output name=deploy::true")
-        else:
-            print("::set-output name=deploy::false")
-            print("::notice title=No updates available::No new spoiler cards found for deployment")
+    # Enable deployment on changes (used in CI)
+    if changed:
+        print("::set-output name=deploy::true")
+    else:
+        print("::set-output name=deploy::false")
+        print("::notice title=No updates available::No new spoiler cards found for deployment")
 
 if __name__ == "__main__":
     main()

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -650,5 +650,6 @@ def main() -> None:
         print("::set-output name=deploy::false")
         print("::notice title=No updates available::No new spoiler cards found for deployment")
 
+
 if __name__ == "__main__":
     main()

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -648,10 +648,9 @@ def main() -> None:
     if os.environ['CI']:
         if changed:
             print("::set-output name=deploy::true")
-            print("::notice title=Updates available::New spoiler files will be uploaded")
         else:
             print("::set-output name=deploy::false")
-            print("::notice title=No updates available::There are no new spoiler cards")
+            print("::notice title=No updates available::No new spoiler cards found for deployment")
 
 if __name__ == "__main__":
     main()

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -408,11 +408,11 @@ def write_spoilers_xml(trice_dicts: Dict[str, List[Dict[str, Any]]]) -> bool:
 
     old_xml_location = str(OUTPUT_DIR.joinpath(output_file_name))
     if compare_xml_content(card_xml_file.name, old_xml_location):
-        print("::notice::No new data in spoiler.xml, skipping replacement")
+        print("No new data in spoiler.xml, skipping replacement")
         return False
 
     # Move new version to old location
-    print("::notice::Changes detected, replacing spoiler.xml with updated version")
+    print("Changes detected, replacing spoiler.xml with updated version")
     shutil.move(card_xml_file.name, old_xml_location)
     return True
 
@@ -644,13 +644,13 @@ def main() -> None:
     changed |= delete_old_files()
 
     # Set output to deploy
-    if changed:
-        print("::set-output name=deploy::true")
-        print("::notice title=Updates available::New spoiler files will be uploaded")
-    else:
-        print("::set-output name=deploy::false")
-        print("::notice title=No updates available::There are no new spoiler cards")
-
+    if CI == true:
+        if changed:
+            print("::set-output name=deploy::true")
+            print("::notice title=Updates available::New spoiler files will be uploaded")
+        else:
+            print("::set-output name=deploy::false")
+            print("::notice title=No updates available::There are no new spoiler cards")
 
 if __name__ == "__main__":
     main()

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -645,7 +645,7 @@ def main() -> None:
     changed |= delete_old_files()
 
     # Set output to deploy
-    if os.environ('CI'):
+    if os.environ['CI']:
         if changed:
             print("::set-output name=deploy::true")
             print("::notice title=Updates available::New spoiler files will be uploaded")


### PR DESCRIPTION
CI doesn't fail when there are no new cards found, as the script run completed successfully.
This adds a hint - well visible in the CI interface - that there are **no new spoiler found** and explains the outcome without looking at the logs in detail.

It is the counterpart to the successful run + **new data deployed** message:
![Untitled](https://user-images.githubusercontent.com/9874850/152545716-13ef5fcc-c985-44a9-a319-2ef6864f3fc5.png)

