### PR TITLE
CI: Exclude .json files from deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add -A . -- ':!*.json'
+          git add *.xml SpoilerSeasonEnabled
           git commit -m "Deploy: $GITHUB_SHA"
           git push
           deploy_commit=`git rev-parse HEAD`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add -A . ':!*.json'
+          git add -A . -- ':!*.json'
           git commit -m "Deploy: $GITHUB_SHA"
           git push
           deploy_commit=`git rev-parse HEAD`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add -A .
+          git add -A . ':!*.json'
           git commit -m "Deploy: $GITHUB_SHA"
           git push
           deploy_commit=`git rev-parse HEAD`


### PR DESCRIPTION
This should address https://github.com/Cockatrice/Magic-Spoiler/issues/262#issuecomment-1030942779 and stop including the json output when committing to the repository.

http://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-exclude

<br>

Edit: Resulting deployment with no more json files -> https://github.com/Cockatrice/Magic-Spoiler/commit/55cab0aceb403ce00c497acc48019855ca18c539