### PR TITLE
remove writing of json files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ It only takes a few days - be patient.
 - If the card is a legitimate spoiler and it isn't showing up yet, you can request it by [contacting the Scryfall support](https://scryfall.com/contact) and let them know. Make sure to link the official spoiler source in your report.
 - If the card shouldn't exist at all, let the Scryfall team know as well, please.
 
-What you should **NOT** do however, is to submit PR's to our files branch and fix the xml/json files there directly.<br>
+What you should **NOT** do however, is to submit PR's to our files branch and fix the xml files there directly.<br>
 You have to provide updates to Scryfall as all other changes would get overridden again.
 
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          git add "*.xml" "*.json" SpoilerSeasonEnabled
+          git add "*.xml" SpoilerSeasonEnabled
           git commit -m "Deploy: $GITHUB_SHA"
           git push
           deploy_commit=`git rev-parse HEAD`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Magic-Spoiler is a Python script to query the <i>[Scryfall](https://scryfall.com
 >**Enable "Download Spoilers Automatically" in `Cockatrice → Settings → Card Sources → Spoilers` to get updates automatically pushed to your client!**<br>
 You can also [add the desired <b>.xml</b> file(s) to your <i>customsets</i> folder manually](https://github.com/Cockatrice/Cockatrice/wiki/Custom-Cards-&-Sets#to-add-custom-sets-follow-these-steps) to make Cockatrice use it.
 
-Just looking for XML or JSON files?  [They are in our `files` branch!](https://github.com/Cockatrice/Magic-Spoiler/tree/files) 
+Just looking for XML files?  [They are in our `files` branch!](https://github.com/Cockatrice/Magic-Spoiler/tree/files) 
 
 When run by our CI, the script automatically updates the files and uploads new versions to this branch. ([History of changes](https://github.com/Cockatrice/Magic-Spoiler/commits/files))<br>
 GitHub Actions are scheduled to autoamtically run on a daily basis.
@@ -43,5 +43,5 @@ All XML and JSON spoiler files are written to the `out/` directory:
 
 | File Name | Content |
 |:--|:--|
-| `spoiler.xml`, `spoiler.json` | files contain **all** currently available spoilers from different **sets** |
-| `{SET_CODE}.xml`, `{SET_CODE}.json` | files contain just the spoiler available for this **single set** |
+| `spoiler.xml` | file contains **all** currently available spoilers from different **sets** |
+| `{SET_CODE}.xml` | files contain just the spoiler available for this **single set** |

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     author="Zach Halpern",
     author_email="zach@cockatrice.us",
     url="https://github.com/Cockatrice/Magic-Spoiler/",
-    description="Build JSON and XML files for distribution of MTG spoiler cards",
+    description="Build XML files for distribution of MTG spoiler cards",
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     license="GPL-3.0",
@@ -19,6 +19,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     ],
-    keywords="Magic: The Gathering, MTG, JSON, Card Games, Collectible, Trading Cards",
+    keywords="Magic: The Gathering, MTG, XML, Card Games, Collectible, Trading Cards",
     packages=setuptools.find_packages(),
 )


### PR DESCRIPTION
internals are unchanged it still uses mtgjsonv4 format as an intermediate step before writing xmls, while this adds complexity it is stable, but writing json files noone can use is unneccesary.

fixes #262 