### PR TITLE
added check for duplicate cards

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -291,6 +291,7 @@ def write_cards(
     :param trice_dict: List of cards
     :param set_code: Set code
     """
+    name_dict = {}
     for card in trice_dict:
         if "names" in card.keys() and card["names"]:
             if "layout" in card and card["layout"] != "double-faced":
@@ -298,6 +299,10 @@ def write_cards(
                     continue
 
         set_name = card["name"]
+        if set_name in name_dict:
+            continue
+        else:
+            name_dict[set_name] = True
 
         if "mana_cost" in card.keys():
             mana_cost = card["mana_cost"].replace("{", "").replace("}", "")


### PR DESCRIPTION
Fixes [#287](https://github.com/Cockatrice/Magic-Spoiler/issues/287) 

Tested on the new spoilers; master has multiple copies of the new cards, this resolves that. Also tested on KHM w/ double-sided cards.

Master:
```
    <card>
      <name>Alrund, God of the Cosmos // Hakka, Whispering Raven</name>
      <text/>
      <prop>
        <type>Legendary Creature — God // Legendary Creature — Bird</type>
        <maintype>Creature</maintype>
        <cmc>5</cmc>
      </prop>
      <set rarity="Mythic Rare" picURL="https://cards.scryfall.io/normal/front/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg?1631054227">KHM</set>
      <tablerow>2</tablerow>
    </card>
    <card>
      <name>Alrund, God of the Cosmos // Hakka, Whispering Raven</name>
      <text/>
      <prop>
        <type>Legendary Creature — God // Legendary Creature — Bird</type>
        <maintype>Creature</maintype>
        <cmc>5</cmc>
      </prop>
      <set rarity="Mythic Rare" picURL="https://cards.scryfall.io/normal/front/5/d/5d131784-c1a3-463e-a37b-b720af67ab62.jpg?1665157358">KHM</set>
      <tablerow>2</tablerow>
    </card>
```
Branch:
```
    <card>
      <name>Alrund, God of the Cosmos // Hakka, Whispering Raven</name>
      <text/>
      <prop>
        <type>Legendary Creature — God // Legendary Creature — Bird</type>
        <maintype>Creature</maintype>
        <cmc>5</cmc>
      </prop>
      <set rarity="Mythic Rare" picURL="https://cards.scryfall.io/normal/front/b/7/b751cf69-0a02-4cd2-abd4-cdb65ca620a8.jpg?1631054227">KHM</set>
      <tablerow>2</tablerow>
    </card>
```

