### PR TITLE
Allow to define a list of set_types to exclude

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -526,6 +526,7 @@ def get_spoiler_sets() -> List[Dict[str, str]]:
         return []
 
     spoiler_sets = []
+    # Find list of possible Set Types to exclude here: https://scryfall.com/docs/api/sets
     excluded_set_types = ["alchemy", "masterpiece", "arsenal", "from_the_vault", "spellbook", "premium_deck", "duel_deck", "treasure_chest", "planechase", "archenemy", "vanguard", "box", "promo", "token", "memorabilia", "minigame"]
 
     for sf_set in sf_sets["data"]:

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -532,7 +532,7 @@ def get_spoiler_sets() -> List[Dict[str, str]]:
     for sf_set in sf_sets["data"]:
         if (
             sf_set["released_at"] >= time.strftime("%Y-%m-%d %H:%M:%S")
-            and sf_set["set_type"].lower() not in excluded_set_types
+            and sf_set["set_type"] not in excluded_set_types
             and sf_set["card_count"]
         ):
             sf_set["code"] = sf_set["code"].upper()

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -526,10 +526,12 @@ def get_spoiler_sets() -> List[Dict[str, str]]:
         return []
 
     spoiler_sets = []
+    excluded_set_types = ["alchemy", "masterpiece", "arsenal", "from_the_vault", "spellbook", "treasure_chest", "box", "promo", "token", "memorabilia", "minigame"]
+
     for sf_set in sf_sets["data"]:
         if (
             sf_set["released_at"] >= time.strftime("%Y-%m-%d %H:%M:%S")
-            and sf_set["set_type"] != "token"
+            and sf_set["set_type"].lower() not in excluded_set_types
             and sf_set["card_count"]
         ):
             sf_set["code"] = sf_set["code"].upper()

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -526,7 +526,7 @@ def get_spoiler_sets() -> List[Dict[str, str]]:
         return []
 
     spoiler_sets = []
-    excluded_set_types = ["alchemy", "masterpiece", "arsenal", "from_the_vault", "spellbook", "treasure_chest", "box", "promo", "token", "memorabilia", "minigame"]
+    excluded_set_types = ["alchemy", "masterpiece", "arsenal", "from_the_vault", "spellbook", "premium_deck", "duel_deck", "treasure_chest", "planechase", "archenemy", "vanguard", "box", "promo", "token", "memorabilia", "minigame"]
 
     for sf_set in sf_sets["data"]:
         if (

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -527,7 +527,9 @@ def get_spoiler_sets() -> List[Dict[str, str]]:
 
     spoiler_sets = []
     # Find list of possible Set Types to exclude here: https://scryfall.com/docs/api/sets
-    excluded_set_types = ["alchemy", "masterpiece", "arsenal", "from_the_vault", "spellbook", "premium_deck", "duel_deck", "treasure_chest", "planechase", "archenemy", "vanguard", "box", "promo", "token", "memorabilia", "minigame"]
+    excluded_set_types = ["alchemy", "masterpiece", "arsenal", "from_the_vault", "spellbook", "premium_deck", "duel_deck",
+                          "draft_innovation", "treasure_chest", "planechase", "archenemy", "vanguard", "box", "promo",
+                          "token", "memorabilia", "minigame"]
 
     for sf_set in sf_sets["data"]:
         if (


### PR DESCRIPTION
Fixes #302

The amount of included sets can get quite crazy with many many cards. Just two weeks ago there were like 10 sets included in the spoiler file, which can create a bit of a mess.
For most people, gift and promo cards or special sets that are not widely legal or can not be played in limited formats are not of interest at all.

Currently, there is `Wizards Play Network 2024` set included with promotional gift cards for example. It can be useful for some to have this, but I like to keep it clean for the huge majority of users. Fewer notifications and popups for new sets in Cockatrice, but more relevant ones.

This allows users to run the script more flexible and to their needs.
We currently exclude token only sets already, I included some more very specific ones to narrow it down to the more relevant sets like core, masters, expansion and commander.

Input for excluded list taken from https://scryfall.com/docs/api/sets

Open for your opinions on my picks!
Was not sure if `funny` should be excluded by default as well.