### PR TITLE
Fix error & more robust MFC handling

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -213,9 +213,8 @@ def scryfall2mtgjson(scryfall_cards: List[Dict[str, Any]]) -> List[Dict[str, Any
     for sf_card in composed_sf_cards:
         super_types, types, sub_types = build_types(sf_card)
 
-        card_faces = sf_card.get("card_faces")
-        if card_faces and isinstance(card_faces, list) and len(card_faces) > 0:
-            image = card_faces[0].get("image_uris", {}).get("normal", "")
+        if "card_faces" in sf_card:
+            image = sf_card["card_faces"][0].get("image_uris", {}).get("normal", "")
         else:
             image = sf_card.get("image_uris", {}).get("normal", "")
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -213,12 +213,9 @@ def scryfall2mtgjson(scryfall_cards: List[Dict[str, Any]]) -> List[Dict[str, Any
     for sf_card in composed_sf_cards:
         super_types, types, sub_types = build_types(sf_card)
 
-        if "//" in sf_card.get("name", ""):
-            image = (
-                sf_card["card_faces"][0]
-                .get("image_uris", {})
-                .get("normal", "")
-            )
+        card_faces = sf_card.get("card_faces")
+        if card_faces and isinstance(card_faces, list) and len(card_faces) > 0:
+            image = card_faces[0].get("image_uris", {}).get("normal", "")
         else:
             image = sf_card.get("image_uris", {}).get("normal", "")
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -214,7 +214,11 @@ def scryfall2mtgjson(scryfall_cards: List[Dict[str, Any]]) -> List[Dict[str, Any
         super_types, types, sub_types = build_types(sf_card)
 
         if "card_faces" in sf_card:
-            image = sf_card["card_faces"][0].get("image_uris", {}).get("normal", "")
+            image = (
+                sf_card["card_faces"][0]
+                .get("image_uris", {})
+                .get("normal", "")
+            )
         else:
             image = sf_card.get("image_uris", {}).get("normal", "")
 


### PR DESCRIPTION
There are no new spoiler populated since over two weeks as the script keeps breaking on some nonexistent `card_faces` keys.
This is not the first time something along the lines happens, see #301 (different root cause).

```
Run python3 -m magic_spoiler
  python3 -m magic_spoiler
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    DEPLOY: true
    OUTPUT_PATH: out
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/Magic-Spoiler/Magic-Spoiler/magic_spoiler/__main__.py", line 661, in <module>
    main()
  File "/home/runner/work/Magic-Spoiler/Magic-Spoiler/magic_spoiler/__main__.py", line 631, in main
    trice_dict = scryfall2mtgjson(cards)
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Magic-Spoiler/Magic-Spoiler/magic_spoiler/__main__.py", line 218, in scryfall2mtgjson
    sf_card["card_faces"][0]
    ~~~~~~~^^^^^^^^^^^^^^
KeyError: 'card_faces'
Downloaded: https://api.scryfall.com/sets/ (Cache = False)
Handling TLA
Downloaded: https://api.scryfall.com/sets/TLA (Cache = False)
Downloaded: https://api.scryfall.com/cards/search?include_extras=true&include_variations=true&order=set&q=e%3Atla&unique=prints (Cache = False)
Changes detected, replacing TLA.xml with updated version
Handling SPE
Downloaded: https://api.scryfall.com/sets/SPE (Cache = False)
Downloaded: https://api.scryfall.com/cards/search?include_extras=true&include_variations=true&order=set&q=e%3Aspe&unique=prints (Cache = False)
Changes detected, replacing SPE.xml with updated version
Handling SPM
Downloaded: https://api.scryfall.com/sets/SPM (Cache = False)
Downloaded: https://api.scryfall.com/cards/search?include_extras=true&include_variations=true&order=set&q=e%3Aspm&unique=prints (Cache = False)
Error: Process completed with exit code 1.
```

<br>

Changed the script to rely on `card_faces` existing for multi-faced cards rather than "//" in the name.
The [API documentation](https://scryfall.com/docs/api/cards) states that `card_faces` is only populated for such cards.

Fixes the above `KeyError: 'card_faces'`.

<br>

See successful CI and output with this change: https://github.com/Cockatrice/Magic-Spoiler/actions/runs/16865590828