### PR TITLE
Add fallback type_line

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -153,7 +153,10 @@ def build_types(sf_card: Dict[str, Any]) -> Tuple[List[str], str, List[str]]:
     super_types: List[str] = []
     sub_types: List[str] = []
 
-    type_line = sf_card["type_line"]
+    # Spoiler cards do not always include a type_line
+    type_line = sf_card.get("type_line", "")
+    if not type_line:
+        type_line = "Unknown"
 
     if "—" in type_line:
         card_subs = type_line.split("—")[1].strip()


### PR DESCRIPTION
Fixes #301 

Automated spoiler runs are stuck again and fail because of a missing card type.

This will handle missing type_line in spoiler cards and puts "Unknown" instead.