### PR TITLE
Add 100ms delay between API requests

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -102,6 +102,8 @@ def json_download(scryfall_url: str) -> Dict[str, Any]:
     """
     session = __get_session()
     response: Any = session.get(url=scryfall_url, timeout=10.0)
+    if not response.from_cache:
+        time.sleep(0.1)    # 100ms delay for good citizenship (10 requests per second)
     request_api_json: Dict[str, Any] = response.json()
     print("Downloaded: {} (Cache = {})".format(scryfall_url, response.from_cache))
     return request_api_json


### PR DESCRIPTION
Try to prevent timeouts that happen unregularly.
This also adheres to the good citizenship the Scryfall API asks for: https://scryfall.com/docs/api

Delay is only added for fresh requests (not cached). Maybe that's not needed?

Recently:
https://github.com/Cockatrice/Magic-Spoiler/actions/runs/20858184171
https://github.com/Cockatrice/Magic-Spoiler/actions/runs/20767318177