### PR TITLE
Add more info to parsing error message

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -251,7 +251,11 @@ def scryfall2mtgjson(scryfall_cards: List[Dict[str, Any]]) -> List[Dict[str, Any
             }
             trice_cards.append(trice_card)
         except Exception as e:
-            print(f"Unable to parse {sf_card.get('name')} ({sf_card.get('set')}): {str(e)}")
+            # If running in GitHub Actions CI, print the message as a warning
+            if 'GITHUB_ACTION' in os.environ:
+                print(f"::warning::Unable to parse {sf_card.get('name')} ({sf_card.get('set')}): {str(e)}")
+            else:
+                print(f"Unable to parse {sf_card.get('name')} ({sf_card.get('set')}): {str(e)}")
 
     return trice_cards
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -251,7 +251,7 @@ def scryfall2mtgjson(scryfall_cards: List[Dict[str, Any]]) -> List[Dict[str, Any
             }
             trice_cards.append(trice_card)
         except Exception as e:
-            print(f"Unable to parse {sf_card.get('name')}, error: {str(e)}")
+            print(f"Unable to parse {sf_card.get('name')} ({sf_card.get('set')}): {str(e)}")
 
     return trice_cards
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -250,8 +250,8 @@ def scryfall2mtgjson(scryfall_cards: List[Dict[str, Any]]) -> List[Dict[str, Any
                 "subTypes": sub_types,
             }
             trice_cards.append(trice_card)
-        except Exception:
-            print(f"Unable to parse {sf_card.get('name')}")
+        except Exception as e:
+            print(f"Unable to parse {sf_card.get('name')}, error: {str(e)}")
 
     return trice_cards
 

--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -250,12 +250,13 @@ def scryfall2mtgjson(scryfall_cards: List[Dict[str, Any]]) -> List[Dict[str, Any
                 "subTypes": sub_types,
             }
             trice_cards.append(trice_card)
+
         except Exception as e:
             # If running in GitHub Actions CI, print the message as a warning
             if 'GITHUB_ACTION' in os.environ:
-                print(f"::warning::Unable to parse {sf_card.get('name')} ({sf_card.get('set')}): {str(e)}")
+                print(f'::warning::Unable to parse "{sf_card.get("name")}" ({sf_card.get("set").upper()}): {str(e)}')
             else:
-                print(f"Unable to parse {sf_card.get('name')} ({sf_card.get('set')}): {str(e)}")
+                print(f'Unable to parse "{sf_card.get("name")}" ({sf_card.get("set").upper()}): {str(e)}')
 
     return trice_cards
 


### PR DESCRIPTION
Before:
```
Unable to parse Blood Crypt // Blood Crypt
Unable to parse Hallowed Fountain // Hallowed Fountain
Unable to parse Overgrown Tomb // Overgrown Tomb
Unable to parse Steam Vents // Steam Vents
Unable to parse Temple Garden // Temple Garden
```

After:
```
Unable to parse "Blood Crypt // Blood Crypt" (ECL): 'cmc'
Unable to parse "Hallowed Fountain // Hallowed Fountain" (ECL): 'cmc'
Unable to parse "Overgrown Tomb // Overgrown Tomb" (ECL): 'cmc'
Unable to parse "Steam Vents // Steam Vents" (ECL): 'cmc'
Unable to parse "Temple Garden // Temple Garden" (ECL): 'cmc'
```

<br>

Additionally, highlight as warning in CI summary and logs:
<img width="600" height="566" alt="image" src="https://github.com/user-attachments/assets/340c23a6-7922-4f42-9eb6-7ebda15f45f0" />

GHA variable: https://docs.github.com/en/actions/reference/workflows-and-actions/variables

<br>

Helps with #238.