### PR TITLE
set headers on all requests

### DIFF
--- a/magic_spoiler/__main__.py
+++ b/magic_spoiler/__main__.py
@@ -90,7 +90,14 @@ def __get_session() -> Union[requests.Session, Any]:
     )
 
     if not SESSION.get(None):
-        SESSION.set(requests.Session())
+        headers = {
+            "Accept": "*/*",
+            "Accept-Encoding": "identity",
+            "User-Agent": "Magic-Spoiler 1.0",
+        }
+        session = requests.Session()
+        session.headers = headers
+        SESSION.set(session)
     return SESSION.get()
 
 


### PR DESCRIPTION
fixes failure in ci: https://github.com/Cockatrice/Magic-Spoiler/actions/runs/27068476121/job/79893361010#step:5:9

scryfall now requires us to set accept and user agent headers, I've also set the accept encoding header